### PR TITLE
fix:this->error can be reset in the middle of validateOrThrow

### DIFF
--- a/app/SchemaValidatorService.php
+++ b/app/SchemaValidatorService.php
@@ -15,6 +15,7 @@ use Illuminate\Support\Facades\Storage;
 use Opis\JsonSchema\Errors\ErrorFormatter;
 use Opis\JsonSchema\Errors\ValidationError;
 use Opis\JsonSchema\Uri;
+use Opis\JsonSchema\ValidationResult;
 use Opis\JsonSchema\Validator;
 use Symfony\Component\HttpFoundation\Response;
 
@@ -22,12 +23,6 @@ class SchemaValidatorService
 {
     /** @var Validator */
     protected $validator = null;
-
-    /**
-     * error from the most recent ->validate() call
-     * @var ValidationError
-     */
-    protected $error = null;
 
     /**
      * As needed, build a validator in memory that knows how to load schema from local disk.
@@ -60,11 +55,24 @@ class SchemaValidatorService
      */
     public function validate($data, $schema): bool
     {
+        $result = $this->validationResult($data, $schema);
+        return $result->isValid();
+    }
+
+    /**
+     * Given data (could be a JsonModel, associative-array style JSON, primitive)
+     * and a schema (could be a URI, an object literal, a JSON-encoded string)
+     * return the ValidationResult of the upstream Opis library.
+     * This is a good approach for methods that want to do their own error formatting through a deeper relationship with Opis
+     * @param mixed $data
+     * @param mixed $schema
+     * @return ValidationResult
+     */
+    public function validationResult($data, $schema): ValidationResult
+    {
         $validator = $this->getValidator();
         $data = $this->normalizeData($data);
-        $result = $validator->validate($data, $schema);
-        $this->error = $result->error();
-        return $result->isValid();
+        return $validator->validate($data, $schema);
     }
 
     /**
@@ -78,28 +86,6 @@ class SchemaValidatorService
     private function normalizeData($data)
     {
         return json_decode(json_encode($data, JSON_THROW_ON_ERROR));
-    }
-
-    /**
-     * Return an array of errors from the last *Validation call
-     * @return ValidationError|null
-     */
-    public function getError(): ?ValidationError
-    {
-        return $this->error;
-    }
-
-    /**
-     * Return an array of human readable errors from the last *Validation call
-     * @return array
-     */
-    public function getFormattedError(): array
-    {
-        if (!$this->error) {
-            return [];
-        }
-
-        return (new ErrorFormatter())->formatFlat($this->error);
     }
 
     /**
@@ -122,24 +108,24 @@ class SchemaValidatorService
         bool $appendValidationDescriptions = false,
         int $failureHttpStatusCode = Response::HTTP_BAD_REQUEST,
     ): bool {
-        if ($this->validate($data, $schema) === false) {
+        $results = $this->validationResult($data, $schema);
+        if ($results->isValid() === false) {
             $message = $exceptionMessage ?: 'Request body contains invalid data!';
-            $error = $this->error;
 
             if ($appendValidationDescriptions) {
                 $prepend = "\r\n* ";
-                $message .= $prepend . implode($prepend, $this->getFormattedError());
+                $message .= $prepend . implode($prepend, (new ErrorFormatter())->formatFlat($results->error()));
             }
 
             Log::debug(
                 "Json Schema Validation Error",
                 [
-                    'error' => (new ErrorFormatter())->format($error, true, null, null),
+                    'error' => (new ErrorFormatter())->format($results->error(), true, null, null),
                     'data' => $data
                 ]
             );
 
-            throw new JsonSchemaValidationException($message, $error, null, $failureHttpStatusCode);
+            throw new JsonSchemaValidationException($message, $results->error(), null, $failureHttpStatusCode);
         }
 
         return true;

--- a/app/SchemaValidatorService.php
+++ b/app/SchemaValidatorService.php
@@ -124,6 +124,7 @@ class SchemaValidatorService
     ): bool {
         if ($this->validate($data, $schema) === false) {
             $message = $exceptionMessage ?: 'Request body contains invalid data!';
+            $error = $this->error;
 
             if ($appendValidationDescriptions) {
                 $prepend = "\r\n* ";
@@ -133,12 +134,12 @@ class SchemaValidatorService
             Log::debug(
                 "Json Schema Validation Error",
                 [
-                    'error' => (new ErrorFormatter())->format($this->error, true, null, null),
+                    'error' => (new ErrorFormatter())->format($error, true, null, null),
                     'data' => $data
                 ]
             );
 
-            throw new JsonSchemaValidationException($message, $this->getError(), null, $failureHttpStatusCode);
+            throw new JsonSchemaValidationException($message, $error, null, $failureHttpStatusCode);
         }
 
         return true;

--- a/app/Traits/JsonSchemaAssertions.php
+++ b/app/Traits/JsonSchemaAssertions.php
@@ -22,23 +22,18 @@ trait JsonSchemaAssertions
      * @param string $schemaUri
      * @param mixed $object
      * @param string $message
-     * @param bool $addFormattedErrorToMessage
      * @return void
      */
     public static function assertValidForSchema(
         string $schemaUri,
                $object,
         string $message = '',
-        bool $addFormattedErrorToMessage = true,
     ): void {
-        $validates = SchemaValidator::validate($object, $schemaUri);
-
-        if ($addFormattedErrorToMessage) {
-            $prepend = "\r\n* ";
-            $message .= "\r\n" . $prepend . implode($prepend, SchemaValidator::getFormattedError());
+        try {
+            self::assertTrue(SchemaValidator::validate($object, $schemaUri), $message);
+        } catch (JsonSchemaValidationException $e) {
+            self::assertCanonicallySame([], $e->errors(), $message);
         }
-
-        static::assertThat($validates, static::isTrue(), $message);
     }
 
     /**
@@ -65,6 +60,4 @@ trait JsonSchemaAssertions
             self::assertCanonicallySame([], $e->errors(), 'Validation failed with errors.');
         }
     }
-
-
 }


### PR DESCRIPTION
Caught a problem in production where some times validateOrThrow will throw a type error 
```
"Carsdotcom\\JsonSchemaValidation\\Exceptions\\JsonSchemaValidationException::__construct(): Argument #2 ($error) must be of type Opis\\JsonSchema\\Errors\\ValidationError, null given, called in /var/www/html/vendor/carsdotcom/laravel-json-schema/app/SchemaValidatorService.php on line 141"
```

I wasn't able to reproduce the problem in a unit test (even using an exact copy of this DealData **and** an export-import of the Account). I ended up copy-pasting the implementation of `validateOrThrow` into Tinker on the affected Kubernetes pod, where I **was** able to reproduce, and experimenting with echo statements and iteratively rewriting.

The problem appears to be that in a complicated app, the `Log::debug` call can synchronously involve other systems, some of which may also be using this Facade to validate other data. In some roundabout way `Log::debug` is causing SchemaValidatorService::error to be reset to `null` -- because SchemaValidatorProvider is intentionally designed to be a `singleton` that `$error` property is effectively a global. Yikes!

The fix in Tinker was to get error into a local variable at the top of the method. But I think the right fix for the library is to obsolete the pattern where `validate` returns a boolean, then the race is on to get the `error` -- instead I introduced a method that returns the full `\Opis\JsonSchema\ValidationResult` (both boolean valid plus the errors array, in one bundle) and refactored validateOrThrow to use that method. I also totally obsoleted the idea of getting the `error` in a separate call, since as a singleton that can't ever be totally safe.