### PR TITLE
feat: Add a clear method to validate encoded JSON strings

### DIFF
--- a/app/SchemaValidator.php
+++ b/app/SchemaValidator.php
@@ -16,8 +16,9 @@ use Symfony\Component\HttpFoundation\Response;
  * @method static array|object getSchemaContents(string $relativeUri, bool $associative = true)
  * @method static void putSchemaContents(string $relativeUri, array|object $schema)
  * @method static string registerRawSchema(bool|object|string $schema)
- * @method static bool validate(array|object $data, string $schema)
- * @method static bool validateOrThrow(string|array|object $data, string $schema, string $exceptionMessage = null, bool $appendValidationDescriptions = false, int $failureHttpStatusCode = Response::HTTP_BAD_REQUEST)
+ * @method static bool validate(mixed $data, string $schema)
+ * @method static bool validateOrThrow(mixed $data, string $schema, string $exceptionMessage = null, bool $appendValidationDescriptions = false, int $failureHttpStatusCode = Response::HTTP_BAD_REQUEST)
+ * @method static bool validateEncodedStringOrThrow(mixed $data, string $schema, string $exceptionMessage = null, bool $appendValidationDescriptions = false, int $failureHttpStatusCode = Response::HTTP_BAD_REQUEST)
  */
 class SchemaValidator extends Facade
 {

--- a/app/SchemaValidatorService.php
+++ b/app/SchemaValidatorService.php
@@ -139,6 +139,24 @@ class SchemaValidatorService
     }
 
     /**
+     * This method will attempt to validate the provided JSON-encoded string against the provided schema.
+     */
+    public function validateEncodedStringOrThrow(
+        string $data,
+        $schema,
+        string $exceptionMessage = null,
+        bool $appendValidationDescriptions = false,
+        int $failureHttpStatusCode = Response::HTTP_BAD_REQUEST,
+    ): bool
+    {
+        // Using the non-associative decode is both how Opis documents it
+        // https://opis.io/json-schema/2.x/quick-start.html
+        // and is known to avoid `{}` vs `[]` confusion
+        $decodedData = json_decode($data, associative: false, flags: JSON_THROW_ON_ERROR);
+        return $this->validateOrThrow($decodedData, $schema, $exceptionMessage, $appendValidationDescriptions, $failureHttpStatusCode);
+    }
+
+    /**
      * Given anything that Opis can use as a schema (object, boolean, json-encoded string)
      * register the schema into our namespace, so it can safely contain relative links of its own.
      * The returned string can be used as the second arg to ->validate.

--- a/tests/Feature/SchemaValidatorServiceTest.php
+++ b/tests/Feature/SchemaValidatorServiceTest.php
@@ -6,6 +6,7 @@ declare(strict_types=1);
 
 namespace Tests\Feature;
 
+use Carsdotcom\JsonSchemaValidation\Exceptions\JsonSchemaValidationException;
 use Carsdotcom\JsonSchemaValidation\SchemaValidatorService;
 use Illuminate\Support\Facades\Config;
 use Opis\JsonSchema\Exceptions\UnresolvedReferenceException;
@@ -87,4 +88,38 @@ class SchemaValidatorServiceTest extends BaseTestCase
         self::assertStringStartsWith(Config::get('json-schema.base_url'), $absoluteRaw);
         self::assertTrue($validator->validate($vins, $absoluteRaw));
     }
+
+    /**
+     * @dataProvider provideValidateEncodedStringOrThrow
+     */
+    public function testValidateEncodedStringOrThrow(string $encodedData, mixed $schema, bool $expectedSuccess): void
+    {
+        $validator = new SchemaValidatorService();
+
+        try {
+            self::assertTrue($validator->validateEncodedStringOrThrow($encodedData, $schema));
+            if (!$expectedSuccess) {
+                self::fail("Should have thrown JsonSchemaValidationException");
+            }
+        } catch (JsonSchemaValidationException $e) {
+            if ($expectedSuccess) {
+                self::assertTrue(false, "Expected success, instead got " . $e->errorsAsMultilineString());
+            } else {
+                self::addToAssertionCount(1);
+            }
+        }
+    }
+
+    public function provideValidateEncodedStringOrThrow(): array
+    {
+        return [
+            'primitive, string schema' => ['420', '{"type": "number", "minimum": 69}', true],
+            'primitive, string schema fails' => ['42', '{"type": "number", "minimum": 69}', false],
+            'empty object is still an object' => ['{}', '{"type": "object"}', true],
+            'empty object is not an array' => ['{}', '{"type": "array"}', false],
+            'typical complex object, success' => ['{"a":1}', '{"type":"object","properties":{"a":{"type":"number"}}, "required":["a"]}', true],
+            'typical complex object, failure' => ['{"b":1}', '{"type":"object","properties":{"a":{"type":"number"}}, "required":["a"]}', false],
+        ];
+    }
+
 }


### PR DESCRIPTION
There are legitimate reasons that users of this library could mostly prefer JSON decoded into associative arrays. (especially because it's what Laravel preferred for years and years)

But associative decoding can introduce schema validation bugs like `{}` vs `[]` confusion that can't happen in object-decoded format.

Introducing a clear method that the caller can use to validate "I received exactly this JSON string, and while I will keep my own counsel about how my own app will decode it, the schema validation library can tell me right now if the **string** is valid or not."