### PR TITLE
Update SchemaValidatorService.php to fix deprecation notice

### DIFF
--- a/app/SchemaValidatorService.php
+++ b/app/SchemaValidatorService.php
@@ -111,7 +111,7 @@ class SchemaValidatorService
     public function validateOrThrow(
         $data,
         $schema,
-        string $exceptionMessage = null,
+        ?string $exceptionMessage = null,
         bool $appendValidationDescriptions = false,
         int $failureHttpStatusCode = Response::HTTP_BAD_REQUEST,
     ): bool {
@@ -144,7 +144,7 @@ class SchemaValidatorService
     public function validateEncodedStringOrThrow(
         string $data,
         $schema,
-        string $exceptionMessage = null,
+        ?string $exceptionMessage = null,
         bool $appendValidationDescriptions = false,
         int $failureHttpStatusCode = Response::HTTP_BAD_REQUEST,
     ): bool


### PR DESCRIPTION
```sh
NOTICE: PHP message: PHP Deprecated:  Carsdotcom\JsonSchemaValidation\SchemaValidatorService::validateEncodedStringOrThrow(): Implicitly marking parameter $exceptionMessage as nullable is deprecated, the explicit nullable type must be used instead in /var/www/vendor/carsdotcom/laravel-json-schema/app/SchemaValidatorService.php on line 144
```

This seems to resolve a deprecation warning that I'm seeing. Not a full time PHP dev, not sure if this the correct way to address this.