### PR TITLE
feat: Adds assertions that canonicalize JSON encoded values

### DIFF
--- a/app/Helpers/Json.php
+++ b/app/Helpers/Json.php
@@ -1,0 +1,149 @@
+<?php
+/**
+ * Imported from PHPUnit\Util\Json
+ *
+ * We need these methods to cheaply do deep-object comparison,
+ * (e.g. in HasJsonModelAttributes::isJsonModelAttributeDirty)
+ * but we don't install PHPUnit in production.
+ */
+
+namespace Carsdotcom\JsonSchemaValidation\Helpers;
+
+use Illuminate\Support\Arr;
+use Illuminate\Support\Str;
+use InvalidArgumentException;
+use function count;
+use function is_array;
+use function is_object;
+use function json_decode;
+use function json_encode;
+use function json_last_error;
+use function ksort;
+
+/**
+ * Class Json
+ * @package App\Helpers
+ */
+class Json
+{
+    /**
+     * Given a complex object, especially one with "magic" properties that would fail property_exists,
+     * remove all the magic. (Like a Muggle https://en.wikipedia.org/wiki/Muggle)
+     * turn it into a simple array or standard-object representation.
+     * Uses JSON so arbitrary depth all gets mugglified at once.
+     * @param $stuff
+     * @param bool $associativeStyle   Like second arg to json_decode
+     * @return mixed
+     */
+    public static function mugglify($stuff, $associativeStyle = true)
+    {
+        return json_decode(json_encode($stuff), $associativeStyle);
+    }
+
+    /**
+     * To allow comparison of JSON strings, first process them into a consistent
+     * format so that they can be compared as strings.
+     * @param string $json
+     * @param int $options
+     * @return string
+     */
+    public static function canonicalize(string $json, int $options = 0): string
+    {
+        $decodedJson = self::decodeOrThrow($json);
+
+        self::recursiveSort($decodedJson);
+
+        $reencodedJson = json_encode($decodedJson, $options);
+
+        return $reencodedJson;
+    }
+
+    /**
+     * Compare any two JSON serializable things, where order of string object properties is ignored.
+     * Returns true if they are, canonically, identical
+     * @param $thing1
+     * @param $thing2
+     * @return bool
+     * @throws \Exception
+     */
+    public static function canonicallySame($thing1, $thing2): bool
+    {
+        return self::canonicalize(json_encode($thing1)) === self::canonicalize(json_encode($thing2));
+    }
+
+    /**
+     * Compare any two JSON serializable things, where order of string object properties is ignored.
+     * Creates an internal muggle representation without the dotted-notation keys in $ignoreKeys
+     * Returns true if those muggles are, canonically, identical
+     * @param $thing1
+     * @param $thing2
+     * @param array $ignoreKeys
+     * @return bool
+     * @throws \Exception
+     */
+    public static function canonicallySameExcept($thing1, $thing2, array $ignoreKeys): bool
+    {
+        $muggle1 = self::mugglify($thing1);
+        Arr::forget($muggle1, $ignoreKeys);
+        $muggle2 = self::mugglify($thing2);
+        Arr::forget($muggle2, $ignoreKeys);
+        return self::canonicallySame($muggle1, $muggle2);
+    }
+
+    /*
+     * JSON object keys are unordered while PHP array keys are ordered.
+     * Sort all array keys to ensure both the expected and actual values have
+     * their keys in the same order.
+     */
+    private static function recursiveSort(&$json): void
+    {
+        if (is_array($json) === false) {
+            // If the object is not empty, change it to an associative array
+            // so we can sort the keys (and we will still re-encode it
+            // correctly, since PHP encodes associative arrays as JSON objects.)
+            // But EMPTY objects MUST remain empty objects. (Otherwise we will
+            // re-encode it as a JSON array rather than a JSON object.)
+            // See #2919.
+            if (is_object($json) && count((array) $json) > 0) {
+                $json = (array) $json;
+            } else {
+                return;
+            }
+        }
+
+        ksort($json);
+
+        foreach ($json as $key => &$value) {
+            self::recursiveSort($value);
+        }
+    }
+
+    /**
+     * Wrapper for json_decode that throws when an error occurs.
+     * Cloned here from Guzzle, to make it obvious that it behaves differently from the builtin language function.
+     *
+     * @param string $json    JSON data to parse
+     * @param bool $assoc     When true, returned objects will be converted
+     *                        into associative arrays.
+     * @param int    $depth   User specified recursion depth.
+     * @param int    $options Bitmask of JSON decode options.
+     *
+     * @return mixed
+     * @throws InvalidArgumentException if the JSON cannot be decoded.
+     * @link http://www.php.net/manual/en/function.json-decode.php
+     */
+    public static function decodeOrThrow($json, $assoc = false, $depth = 512, $options = 0)
+    {
+        $data = json_decode($json, $assoc, $depth, $options);
+        if (JSON_ERROR_NONE !== json_last_error()) {
+            throw new InvalidArgumentException('json_decode error: ' . json_last_error_msg());
+        }
+
+        return $data;
+    }
+
+    public static function isObject($mixed): bool
+    {
+        return Str::startsWith(json_encode($mixed, flags: JSON_THROW_ON_ERROR), '{');
+    }
+}

--- a/app/Traits/JsonSchemaAssertions.php
+++ b/app/Traits/JsonSchemaAssertions.php
@@ -6,13 +6,37 @@ declare(strict_types=1);
 
 namespace Carsdotcom\JsonSchemaValidation\Traits;
 
-
 use Carsdotcom\JsonSchemaValidation\Contracts\CanValidate;
 use Carsdotcom\JsonSchemaValidation\Exceptions\JsonSchemaValidationException;
+use Carsdotcom\JsonSchemaValidation\Helpers\Json;
 use Carsdotcom\JsonSchemaValidation\SchemaValidator;
+use PHPUnit\Framework\Assert;
 
+/**
+ * @mixin Assert  This trait should be added to PHPUnit test classes, usually BaseTestCase
+ */
 trait JsonSchemaAssertions
 {
+    /**
+     * Given two things that support JSON encoding,
+     * assert that they are identical in their canonicalized (sorted props), stringified form
+     * @param mixed $a literally anything that can be JSON encoded
+     * @param mixed $b literally anything that can be JSON encoded
+     */
+    public static function assertCanonicallySame(mixed $a, mixed $b, string $comment = ''): void
+    {
+        $cannonA = Json::canonicalize(json_encode($a), JSON_PRETTY_PRINT | JSON_UNESCAPED_SLASHES);
+        $cannonB = Json::canonicalize(json_encode($b), JSON_PRETTY_PRINT | JSON_UNESCAPED_SLASHES);
+        self::assertSame($cannonA, $cannonB, $comment);
+    }
+
+    public function assertCanonicallySameExcept($a, $b, array $ignoredKeys, string $comment = ''): void
+    {
+        $a = collect($a)->except($ignoredKeys)->toArray();
+        $b = collect($b)->except($ignoredKeys)->toArray();
+        self::assertCanonicallySame($a, $b, $comment);
+    }
+
     /**
      * The passed Object validates for the passed Json Schema
      *

--- a/tests/BaseTestCase.php
+++ b/tests/BaseTestCase.php
@@ -2,10 +2,13 @@
 
 namespace Tests;
 
+use Carsdotcom\JsonSchemaValidation\Traits\JsonSchemaAssertions;
 use Orchestra\Testbench\TestCase;
 
 class BaseTestCase extends TestCase
 {
+    use JsonSchemaAssertions;
+
     /**
      * Define environment setup.
      *

--- a/tests/Unit/Helpers/JsonTest.php
+++ b/tests/Unit/Helpers/JsonTest.php
@@ -1,0 +1,98 @@
+<?php
+/**
+ * Unit tests for JSON helpers.
+ * Note the original class was imported from PHPUnit utilities, so these tests aren't exhaustive
+ */
+
+namespace Tests\Unit\Helpers;
+
+use Carsdotcom\JsonSchemaValidation\Helpers\Json;
+use Illuminate\Support\Collection;
+use Tests\BaseTestCase;
+use Tests\Mocks\Models\Vehicle;
+
+class JsonTest extends BaseTestCase
+{
+    public function testMugglifyPropertyExists()
+    {
+        $vehicle = Vehicle::factory()->make(['vin' => '11111111111111111']);
+        self::assertFalse(property_exists($vehicle, 'vin'), 'property_exists fails for class object');
+        $flatVehicle = Json::mugglify($vehicle, false);
+        self::assertTrue(property_exists($flatVehicle, 'vin'), 'property_exists succeeds after flattening');
+    }
+
+    public function testCanonicalize()
+    {
+        $ab = '{ "a" : 1, "b" : 2 }';
+        $ba = '{ "b" : 2, "a" : 1 }';
+
+        self::assertNotSame($ab, $ba);
+        self::assertSame('{"a":1,"b":2}', Json::canonicalize($ab), 'No change to order, normalizes whitespace');
+        self::assertSame('{"a":1,"b":2}', Json::canonicalize($ba));
+        self::assertSame(Json::canonicalize($ab), Json::canonicalize($ba));
+    }
+
+    /**
+     * @param $thing1
+     * @param $thing2
+     * @param $expected
+     * @throws \Exception
+     * @dataProvider provideCanonicallySame
+     */
+    public function testCanonicallySame($thing1, $thing2, bool $expected)
+    {
+        self::assertSame($expected, Json::canonicallySame($thing1, $thing2));
+    }
+
+    public static function provideCanonicallySame(): iterable
+    {
+        return [
+            'simple strings match' => ['ab', 'ab', true],
+            'simple strings miss' => ['ab', 'abc', false],
+            'null and false not equivalent' => [null, false, false],
+            'string and number not equivalent' => ['0', 0, false],
+            'equal properties match' => [['a' => 1, 'b' => 2], ['a' => 1, 'b' => 2], true],
+            'unequal properties miss' => [['a' => 2, 'b' => 2], ['a' => 1, 'b' => 2], false],
+            'ignores property order, match' => [['a' => 1, 'b' => 2], ['b' => 2, 'a' => 1], true],
+        ];
+    }
+
+    public function testDecodeOrThrowThrows(): void
+    {
+        $this->expectException(\InvalidArgumentException::class);
+        $this->expectExceptionMessage('json_decode error: Syntax error');
+        Json::decodeOrThrow('{"incomplete":');
+    }
+
+    public function testDecodeOrThrowIsCoolWithNull(): void
+    {
+        // The way it notices decode errors isn't based on the return value of json_decode
+        self::assertNull(Json::decodeOrThrow('null'));
+    }
+
+    /**
+     * @dataProvider provideIsObject
+     */
+    public function testIsObject(mixed $subject, bool $expected): void
+    {
+        self::assertSame($expected, Json::isObject($subject));
+    }
+
+    public static function provideIsObject(): iterable
+    {
+        return [
+            [null, false],
+            [0, false],
+            [1, false],
+            [1.1, false],
+            ['stringy', false],
+            ['Object', false],
+            [false, false],
+            [[], false],
+            [new Collection(), false],
+            [(object) [], true],
+            [['foo' => 'bar'], true],
+            [(object) ['foo' => 'bar'], true],
+        ];
+    }
+}


### PR DESCRIPTION
Resolves issue #10 
Weirdly, this library shipped assertions that *depend* on assertCanonicallySame but don't *provide* it.
We also noticed in the Incentives project that we wanted to use assertCanonicallySameExcept but that was local ONLY to Online Shopper and not shared anywhere.