### PR TITLE
feat: PHP 8.4 Support

### DIFF
--- a/app/Contracts/CanValidate.php
+++ b/app/Contracts/CanValidate.php
@@ -20,5 +20,5 @@ interface CanValidate
      * @throws Exception if the data is invalid. Exact exception is up to the implementation,
      * but should implement HasExtendedExceptionData like JsonSchemaValidationException
      */
-    public function validateOrThrow(string $exceptionMessage = null): bool;
+    public function validateOrThrow(?string $exceptionMessage = null): bool;
 }

--- a/app/Exceptions/JsonSchemaValidationException.php
+++ b/app/Exceptions/JsonSchemaValidationException.php
@@ -13,6 +13,7 @@ use Opis\JsonSchema\Errors\ErrorFormatter;
 use Opis\JsonSchema\Errors\ValidationError;
 use RuntimeException;
 use Symfony\Component\HttpFoundation\Response;
+use Throwable;
 
 /**
  * Class JsonSchemaValidationException
@@ -23,7 +24,7 @@ class JsonSchemaValidationException extends RuntimeException implements HasExten
     public function __construct(
         string $message,
         protected ValidationError $error,
-        \Throwable $previous = null,
+        ?Throwable $previous = null,
         protected int $failureHttpStatusCode = Response::HTTP_BAD_REQUEST,
     ) {
         parent::__construct(message: $message, code: $failureHttpStatusCode, previous: $previous);

--- a/app/SchemaValidatorService.php
+++ b/app/SchemaValidatorService.php
@@ -14,7 +14,6 @@ use Illuminate\Contracts\Filesystem\FileNotFoundException;
 use Illuminate\Support\Facades\Log;
 use Illuminate\Support\Facades\Storage;
 use Opis\JsonSchema\Errors\ErrorFormatter;
-use Opis\JsonSchema\Errors\ValidationError;
 use Opis\JsonSchema\Uri;
 use Opis\JsonSchema\ValidationResult;
 use Opis\JsonSchema\Validator;

--- a/app/Traits/ValidatesWithJsonSchema.php
+++ b/app/Traits/ValidatesWithJsonSchema.php
@@ -18,7 +18,7 @@ trait ValidatesWithJsonSchema
      * @throws JsonSchemaValidationException   if data is invalid
      */
     public function validateOrThrow(
-        string $exceptionMessage = null,
+        ?string $exceptionMessage = null,
         int $failureHttpStatusCode = Response::HTTP_BAD_REQUEST,
     ): bool {
         if (!defined(static::class . '::SCHEMA') || !static::SCHEMA) {


### PR DESCRIPTION
- Make the validateOrThrow message parameter nullable in the CanValidate contract and ValidatesWithJsonSchema trait (?string).
- Update JsonSchemaValidationException to import Throwable and type the previous exception as ?Throwable.
- Remove an unused ValidationError import from SchemaValidatorService.
- These are non-functional type/cleanup changes to reflect nullable values and tidy imports.