### PR TITLE
feat: add PHP 8.3/8.4/8.5 and Laravel 13 test matrix coverage

### DIFF
--- a/.github/workflows/tests.yaml
+++ b/.github/workflows/tests.yaml
@@ -8,12 +8,22 @@ jobs:
 
     strategy:
       matrix:
-        php: ['8.2']
-        laravel: [9.*, 10.*, 11.*, 12.*]
+        php: ['8.3', '8.4', '8.5']
+        laravel: [11.*, 12.*, 13.*]
         include:
           - php: 8.1
             laravel: 9.*
           - php: 8.1
+            laravel: 10.*
+          - php: 8.2
+            laravel: 9.*
+          - php: 8.2
+            laravel: 10.*
+          - php: 8.2
+            laravel: 11.*
+          - php: 8.2
+            laravel: 12.*
+          - php: 8.3
             laravel: 10.*
 
     name: Unit Tests - PHP ${{ matrix.php }} - Laravel ${{ matrix.laravel }}

--- a/composer.json
+++ b/composer.json
@@ -10,17 +10,17 @@
     ],
     "license": "MIT",
     "require": {
-        "laravel/framework": "^9.19 || ^10.0 || ^11.0 || ^12.0",
+        "laravel/framework": "^9.19 || ^10.0 || ^11.0 || ^12.0 || ^13.0",
         "opis/json-schema": "^2.3",
         "php": "^8.1"
     },
     "require-dev": {
         "fakerphp/faker": "^1.9.1",
         "mockery/mockery": "^1.4.4",
-        "nunomaduro/collision": "^6.1|7.*|8.*",
-        "orchestra/testbench": "7.*|8.*|9.*|10.*",
+        "nunomaduro/collision": "^6.1|7.*|8.*|9.*|10.*",
+        "orchestra/testbench": "7.*|8.*|9.*|10.*|11.*",
         "phpstan/phpstan": "^1.8|^2.1",
-        "phpunit/phpunit": "~8.0|~9.0|^10.5|^11.5.3",
+        "phpunit/phpunit": "~8.0|~9.0|^10.5|^11.5.3|^12.0",
         "squizlabs/php_codesniffer": "^3.7"
     },
     "autoload": {

--- a/tests/Feature/JsonSchemaValidationExceptionTest.php
+++ b/tests/Feature/JsonSchemaValidationExceptionTest.php
@@ -9,6 +9,7 @@ namespace Tests\Feature;
 
 use Carsdotcom\JsonSchemaValidation\Exceptions\JsonSchemaValidationException;
 use Carsdotcom\JsonSchemaValidation\SchemaValidator;
+use PHPUnit\Framework\Attributes\DataProvider;
 use Tests\BaseTestCase;
 
 class JsonSchemaValidationExceptionTest extends BaseTestCase
@@ -36,6 +37,7 @@ class JsonSchemaValidationExceptionTest extends BaseTestCase
     /**
      * @dataProvider provideErrorsFormattedLikeMessageBag
      */
+    #[DataProvider('provideErrorsFormattedLikeMessageBag')]
     public function testErrorsFormattedLikeMessageBag($data, string $schema, array $expectedErrors): void
     {
         try {

--- a/tests/Feature/SchemaValidatorServiceTest.php
+++ b/tests/Feature/SchemaValidatorServiceTest.php
@@ -10,6 +10,7 @@ use Carsdotcom\JsonSchemaValidation\Exceptions\JsonSchemaValidationException;
 use Carsdotcom\JsonSchemaValidation\SchemaValidatorService;
 use Illuminate\Support\Facades\Config;
 use Opis\JsonSchema\Exceptions\UnresolvedReferenceException;
+use PHPUnit\Framework\Attributes\DataProvider;
 use Tests\BaseTestCase;
 use Tests\Mocks\Models\Vehicle;
 
@@ -55,6 +56,7 @@ class SchemaValidatorServiceTest extends BaseTestCase
      * @param $schema
      * @dataProvider normalizeDataProvider
      */
+    #[DataProvider('normalizeDataProvider')]
     public function testNormalizeData($data, $schema): void
     {
         $validator = new SchemaValidatorService();
@@ -92,6 +94,7 @@ class SchemaValidatorServiceTest extends BaseTestCase
     /**
      * @dataProvider provideValidateEncodedStringOrThrow
      */
+    #[DataProvider('provideValidateEncodedStringOrThrow')]
     public function testValidateEncodedStringOrThrow(string $encodedData, mixed $schema, bool $expectedSuccess): void
     {
         $validator = new SchemaValidatorService();

--- a/tests/Unit/Helpers/JsonTest.php
+++ b/tests/Unit/Helpers/JsonTest.php
@@ -8,6 +8,7 @@ namespace Tests\Unit\Helpers;
 
 use Carsdotcom\JsonSchemaValidation\Helpers\Json;
 use Illuminate\Support\Collection;
+use PHPUnit\Framework\Attributes\DataProvider;
 use Tests\BaseTestCase;
 use Tests\Mocks\Models\Vehicle;
 
@@ -39,6 +40,7 @@ class JsonTest extends BaseTestCase
      * @throws \Exception
      * @dataProvider provideCanonicallySame
      */
+    #[DataProvider('provideCanonicallySame')]
     public function testCanonicallySame($thing1, $thing2, bool $expected)
     {
         self::assertSame($expected, Json::canonicallySame($thing1, $thing2));
@@ -73,6 +75,7 @@ class JsonTest extends BaseTestCase
     /**
      * @dataProvider provideIsObject
      */
+    #[DataProvider('provideIsObject')]
     public function testIsObject(mixed $subject, bool $expected): void
     {
         self::assertSame($expected, Json::isObject($subject));


### PR DESCRIPTION
## Summary

- Adds PHP 8.3, 8.4, and 8.5 to the CI test matrix
- Adds Laravel 13 support (requires PHP 8.3+)
- Expands `composer.json` dev dependency version constraints to accommodate new versions (`orchestra/testbench 11.*`, `nunomaduro/collision 9.*|10.*`, `phpunit ^12.0`)
- Declares `laravel/framework ^13.0` as a supported version

**Full matrix (16 combinations):**
- PHP 8.1 × Laravel 9, 10
- PHP 8.2 × Laravel 9, 10, 11, 12
- PHP 8.3 × Laravel 10, 11, 12, 13
- PHP 8.4 × Laravel 11, 12, 13
- PHP 8.5 × Laravel 11, 12, 13

## Test plan

- [x] All 16 CI matrix jobs pass
- [x] No dependency resolution failures from widened version constraints

🤖 Generated with [Claude Code](https://claude.com/claude-code)