### PR TITLE
feat: add dataIsPlainArray fast path to schema normalization

### DIFF
--- a/app/SchemaValidator.php
+++ b/app/SchemaValidator.php
@@ -16,8 +16,8 @@ use Symfony\Component\HttpFoundation\Response;
  * @method static array|object getSchemaContents(string $relativeUri, bool $associative = true)
  * @method static void putSchemaContents(string $relativeUri, array|object $schema)
  * @method static string registerRawSchema(bool|object|string $schema)
- * @method static bool validate(mixed $data, string $schema)
- * @method static bool validateOrThrow(mixed $data, string $schema, string $exceptionMessage = null, bool $appendValidationDescriptions = false, int $failureHttpStatusCode = Response::HTTP_BAD_REQUEST)
+ * @method static bool validate(mixed $data, string $schema, bool $normalizeWithJsonSerializable = true)
+ * @method static bool validateOrThrow(mixed $data, string $schema, string $exceptionMessage = null, bool $appendValidationDescriptions = false, int $failureHttpStatusCode = Response::HTTP_BAD_REQUEST, bool $normalizeWithJsonSerializable = true)
  * @method static bool validateEncodedStringOrThrow(mixed $data, string $schema, string $exceptionMessage = null, bool $appendValidationDescriptions = false, int $failureHttpStatusCode = Response::HTTP_BAD_REQUEST)
  */
 class SchemaValidator extends Facade

--- a/app/SchemaValidatorService.php
+++ b/app/SchemaValidatorService.php
@@ -14,6 +14,7 @@ use Illuminate\Contracts\Filesystem\FileNotFoundException;
 use Illuminate\Support\Facades\Log;
 use Illuminate\Support\Facades\Storage;
 use Opis\JsonSchema\Errors\ErrorFormatter;
+use Opis\JsonSchema\Helper;
 use Opis\JsonSchema\Uri;
 use Opis\JsonSchema\ValidationResult;
 use Opis\JsonSchema\Validator;
@@ -57,11 +58,12 @@ class SchemaValidatorService
      * return whether the data validates against the schema, and hang on to any errors
      * @param mixed $data
      * @param mixed $schema
+     * @param bool $normalizeWithJsonSerializable See {@see normalizeData()} for when to pass false.
      * @return bool
      */
-    public function validate($data, $schema): bool
+    public function validate($data, $schema, bool $normalizeWithJsonSerializable = true): bool
     {
-        $result = $this->validationResult($data, $schema);
+        $result = $this->validationResult($data, $schema, $normalizeWithJsonSerializable);
         return $result->isValid();
     }
 
@@ -72,25 +74,43 @@ class SchemaValidatorService
      * This is a good approach for methods that want to do their own error formatting through a deeper relationship with Opis
      * @param mixed $data
      * @param mixed $schema
+     * @param bool $normalizeWithJsonSerializable See {@see normalizeData()} for when to pass false.
      * @return ValidationResult
      */
-    public function validationResult($data, $schema): ValidationResult
+    public function validationResult($data, $schema, bool $normalizeWithJsonSerializable = true): ValidationResult
     {
         $validator = $this->getValidator();
-        $data = $this->normalizeData($data);
+        $data = $this->normalizeData($data, $normalizeWithJsonSerializable);
         return $validator->validate($data, $schema);
     }
 
     /**
-     * opis/json-schema doesn't accept associative-array style JSON, only object-style.
-     * Since Laravel and a lot of our code uses associative-arrays, this converts it.
-     * This also uses the object's JsonSerializable contract to get the exportable version,
-     * and even converts Collections to flat arrays
+     * opis/json-schema doesn't accept associative-array style JSON, only object-style,
+     * so associative arrays must be converted to stdClass before validation.
+     *
+     * Default ($normalizeWithJsonSerializable = true): round-trip through json_encode/json_decode.
+     * This honors the JsonSerializable contract — JsonModels, Collections, DateTime, etc. are
+     * converted via their serialized form — so it is safe for any input.
+     *
+     * Opt-out ($normalizeWithJsonSerializable = false): convert with Opis' own Helper::toJSON().
+     * It still produces a full object-style copy of the data, but builds it directly instead of
+     * round-tripping through a JSON string, so peak memory holds one structured copy rather than
+     * a structured copy PLUS the full encoded string — a meaningful saving on very large payloads.
+     * Only safe when $data contains no JsonSerializable/Collections/DateTime, because Helper::toJSON()
+     * reads public object properties and does NOT invoke jsonSerialize().
+     *
      * @param mixed $data
+     * @param bool $normalizeWithJsonSerializable
      * @return mixed
      */
-    private function normalizeData($data)
+    private function normalizeData($data, bool $normalizeWithJsonSerializable = true)
     {
+        if (!$normalizeWithJsonSerializable) {
+            // Despite the name, Helper::toJSON returns a PHP stdClass/array tree (not a JSON string):
+            // the object-style structure Opis requires, built without an intermediate encoded string.
+            return Helper::toJSON($data);
+        }
+
         return json_decode(json_encode($data, JSON_THROW_ON_ERROR));
     }
 
@@ -105,6 +125,7 @@ class SchemaValidatorService
      * @param string|null $exceptionMessage
      * @param bool $appendValidationDescriptions
      * @param int $failureHttpStatusCode override what http status code to use on validation failure: default is 400
+     * @param bool $normalizeWithJsonSerializable See {@see normalizeData()} for when to pass false.
      * @return bool
      */
     public function validateOrThrow(
@@ -113,8 +134,9 @@ class SchemaValidatorService
         ?string $exceptionMessage = null,
         bool $appendValidationDescriptions = false,
         int $failureHttpStatusCode = Response::HTTP_BAD_REQUEST,
+        bool $normalizeWithJsonSerializable = true,
     ): bool {
-        $results = $this->validationResult($data, $schema);
+        $results = $this->validationResult($data, $schema, $normalizeWithJsonSerializable);
         if ($results->isValid() === false) {
             $message = $exceptionMessage ?: 'Request body contains invalid data!';
 

--- a/tests/Feature/SchemaValidatorServiceTest.php
+++ b/tests/Feature/SchemaValidatorServiceTest.php
@@ -10,6 +10,7 @@ use Carsdotcom\JsonSchemaValidation\Exceptions\JsonSchemaValidationException;
 use Carsdotcom\JsonSchemaValidation\SchemaValidatorService;
 use Illuminate\Support\Facades\Config;
 use Opis\JsonSchema\Exceptions\UnresolvedReferenceException;
+use Opis\JsonSchema\Helper;
 use PHPUnit\Framework\Attributes\DataProvider;
 use Tests\BaseTestCase;
 use Tests\Mocks\Models\Vehicle;
@@ -123,6 +124,126 @@ class SchemaValidatorServiceTest extends BaseTestCase
             'typical complex object, success' => ['{"a":1}', '{"type":"object","properties":{"a":{"type":"number"}}, "required":["a"]}', true],
             'typical complex object, failure' => ['{"b":1}', '{"type":"object","properties":{"a":{"type":"number"}}, "required":["a"]}', false],
         ];
+    }
+
+    /**
+     * The normalizeWithJsonSerializable: false fast path (Opis Helper::toJSON instead of a
+     * json_encode/json_decode round-trip) must still convert associative arrays to objects so they
+     * validate against object schemas, leave lists as arrays, and pass scalars through.
+     * @param $data
+     * @param $schema
+     * @dataProvider plainArrayNormalizeProvider
+     */
+    #[DataProvider('plainArrayNormalizeProvider')]
+    public function testValidateWithPlainArrayNormalization($data, $schema): void
+    {
+        $validator = new SchemaValidatorService();
+        self::assertTrue($validator->validate($data, $schema, normalizeWithJsonSerializable: false));
+    }
+
+    public static function plainArrayNormalizeProvider(): array
+    {
+        return [
+            'assoc array becomes object' => [
+                ['a' => 1],
+                '{"type":"object","properties":{"a":{"type":"number"}},"required":["a"]}',
+            ],
+            'list stays array' => [
+                [1, 2, 3],
+                '{"type":"array","minItems":3}',
+            ],
+            'real object unmodified' => [
+                (object) ['a' => 1],
+                '{"type":"object","properties":{"a":{"type":"number"}}}',
+            ],
+            'nested assoc within list becomes objects' => [
+                ['items' => [['x' => 1], ['x' => 2]]],
+                '{"type":"object","properties":{"items":{"type":"array","items":{"type":"object","properties":{"x":{"type":"number"}},"required":["x"]}}}}',
+            ],
+            'empty array stays array' => [
+                [],
+                '{"type":"array"}',
+            ],
+            'scalar passes through' => [
+                420,
+                '{"type":"number","minimum":69}',
+            ],
+        ];
+    }
+
+    /**
+     * Safety net for the normalizeWithJsonSerializable: false opt-out: for data composed solely of
+     * arrays, scalars, and stdClass, Helper::toJSON must produce a structure IDENTICAL to the
+     * json_encode/json_decode round-trip.
+     * @param $data
+     * @dataProvider plainDataEquivalenceProvider
+     */
+    #[DataProvider('plainDataEquivalenceProvider')]
+    public function testPlainDataNormalizationMatchesRoundTrip($data): void
+    {
+        $validator = new SchemaValidatorService();
+        $normalizeData = new \ReflectionMethod($validator, 'normalizeData');
+
+        self::assertEquals(
+            $normalizeData->invoke($validator, $data, true),   // round-trip
+            $normalizeData->invoke($validator, $data, false),  // Helper::toJSON
+        );
+    }
+
+    public static function plainDataEquivalenceProvider(): array
+    {
+        return [
+            'scalar int' => [420],
+            'scalar float' => [4.2],
+            'scalar string' => ['hello'],
+            'bool' => [true],
+            'null' => [null],
+            'list' => [[1, 2, 3]],
+            'assoc' => [['a' => 1, 'b' => 'two']],
+            'empty array' => [[]],
+            'stdClass' => [(object) ['a' => 1]],
+            'incentives-shaped offers' => [[
+                'abc123hash' => [
+                    'title' => '2026 Toyota Camry',
+                    'vehicle' => (object) ['vin' => 'JT1234567890', 'year' => '2026', 'msrp' => 30000],
+                    'cash' => ['total' => 500, 0 => ['program_id' => '1', 'total_cash' => 500.0]],
+                    'finance_all' => ['md5key' => ['terms' => [['length' => '60', 'rate' => '1.9']]]],
+                    'lease_all' => [],
+                    'specials' => [],
+                    'valid_vins' => ['JT1234567890', 'JT1234567891'],
+                    'disclaimers' => [],
+                ],
+            ]],
+        ];
+    }
+
+    /**
+     * Objects whose JSON form comes from jsonSerialize() (e.g. a laravel-json-model) MUST use the
+     * default round-trip. Helper::toJSON reads public properties and ignores jsonSerialize(), so
+     * normalizeWithJsonSerializable: false would validate the wrong shape — which is exactly why the
+     * opt-out is unsafe for anything but plain arrays/scalars/stdClass.
+     */
+    public function testJsonSerializableRequiresRoundTripNormalization(): void
+    {
+        // Mirrors how a JsonModel exposes data via jsonSerialize() rather than public properties,
+        // without taking a circular test dependency on carsdotcom/laravel-json-model.
+        $serializable = new class implements \JsonSerializable {
+            public string $model = 'Chevrolet';
+
+            public function jsonSerialize(): mixed
+            {
+                return ['vin' => '11111111111111111'];
+            }
+        };
+
+        self::assertEquals((object) ['model' => 'Chevrolet'], Helper::toJSON($serializable));
+        self::assertEquals((object) ['vin' => '11111111111111111'], json_decode(json_encode($serializable)));
+
+        $validator = new SchemaValidatorService();
+        // Default honors jsonSerialize() -> {"vin": ...} -> a valid Vehicle.
+        self::assertTrue($validator->validate($serializable, 'vehicle.json'));
+        // Opt-out sees only the public {model} property (no vin) -> invalid.
+        self::assertFalse($validator->validate($serializable, 'vehicle.json', normalizeWithJsonSerializable: false));
     }
 
 }


### PR DESCRIPTION
## What

Adds an opt-in `bool $normalizeWithJsonSerializable = true` parameter to `SchemaValidatorService::validate()`, `validationResult()`, and `validateOrThrow()` (and the `SchemaValidator` facade). The default (`true`) is the current `json_decode(json_encode())` round-trip, so this is fully backwards-compatible. When `false`, `normalizeData()` converts with Opis' own `Helper::toJSON()` instead.

## Why

Opis requires object-style data (an associative array validates as type `null`), so `normalizeData()` must convert before validating. The default round-trip materializes a full intermediate JSON string and then decodes it, so at its peak it holds the encoded string **and** the decoded copy at once. `Helper::toJSON()` builds the same object-style copy directly, so peak memory holds one structured copy instead of a copy plus the full string — a meaningful saving on very large payloads.

`Helper::toJSON()` does not invoke `jsonSerialize()` (it reads public object properties), so the opt-out is only safe for data composed of arrays, scalars, and `stdClass` — which is what the parameter name signals. Driven by recurring 6 GB OOMs validating very large response payloads.

## Benchmark — normalize + validate, isolated phase (PHP 8.4)

| Payload | Path | Peak | Transient | Time |
| --- | --- | --- | --- | --- |
| 3,000 entries (~20 MB) | round-trip (default) | 190 MB | 120 MB | 131 ms |
| | `Helper::toJSON` | 128 MB | 58 MB | 271 ms |
| 8,000 entries (~54 MB) | round-trip (default) | 496 MB | 318 MB | 281 ms |
| | `Helper::toJSON` | 328 MB | 150 MB | 659 ms |

~⅓ lower peak and ~½ lower transient memory, at the cost of ~2× CPU on the normalize step (pure-PHP walk vs native `json_*`). A deliberate memory-for-CPU trade, which is why it is opt-in rather than the default.

## Tests

- `testValidateWithPlainArrayNormalization` — the opt-out still converts assoc → object, keeps lists as arrays, and passes scalars through.
- `testPlainDataNormalizationMatchesRoundTrip` (data provider) — `Helper::toJSON` produces output identical to the round-trip for plain data (the safety net).
- `testJsonSerializableRequiresRoundTripNormalization` — a `JsonSerializable` object whose serialized form differs from its public properties: the default path validates it correctly while the opt-out does not, demonstrating exactly why the opt-out is unsafe for such objects.

Full suite green locally (69 tests, 102 assertions).
